### PR TITLE
Add default column and enable user to upload annotations upon uploading video

### DIFF
--- a/src/static_data/basic_column_config.json
+++ b/src/static_data/basic_column_config.json
@@ -1,0 +1,17 @@
+{
+  "columns": {
+      "Header": "Annotations",
+      "columns": [
+          {
+          "Header": "id",
+          "accessor": "id"
+          },
+          {
+          "Header": "Glo23434",
+          "accessor": "global_id"
+          }
+      ]
+  },
+  "select_data": {
+}
+}

--- a/src/static_data/basic_column_config.json
+++ b/src/static_data/basic_column_config.json
@@ -3,11 +3,11 @@
       "Header": "Annotations",
       "columns": [
           {
-          "Header": "id",
+          "Header": "Local ID",
           "accessor": "id"
           },
           {
-          "Header": "Glo23434",
+          "Header": "Global ID",
           "accessor": "global_id"
           }
       ]

--- a/src/ui_elements/Components/nav_bar.js
+++ b/src/ui_elements/Components/nav_bar.js
@@ -193,7 +193,7 @@ export default function CustomNavBar(props){
 						<Form.File disabled={props.disable_buttons} accept=".json" id="file" label="Column Upload" custom type="file" onChange={handleColumnUpload}/>
 					</Form>
 					<Form >
-						<Form.File disabled={!columnLoad} accept=".json" id="file" label="Annotation Upload" custom type="file" onChange={props.handleOldAnnotation}/>
+						<Form.File accept=".json" id="file" label="Annotation Upload" custom type="file" onChange={props.handleOldAnnotation}/>
 					</Form>
 					<NavDropdown.Divider />
 					Frame Rate: <input type="number" onClick={(event) => {props.toggleKeyCheck(false)}} onBlur={(event) => {props.toggleKeyCheck(true)}} onChange={(event) => {setFrameRate(event.target.value);}}></input>

--- a/src/ui_elements/Components/nav_bar.js
+++ b/src/ui_elements/Components/nav_bar.js
@@ -163,7 +163,7 @@ export default function CustomNavBar(props){
 		</Modal>
 		<Modal show={uploadShow} onHide={handleUploadClose} size='lg' backdrop='static'>
 			<Modal.Header>
-				<Modal.Title disabled={!columnLoad}>Upload</Modal.Title>
+				<Modal.Title>Upload</Modal.Title>
 			</Modal.Header>
 			<Modal.Body>
 				<div style={{display: "grid"}}>
@@ -203,7 +203,7 @@ export default function CustomNavBar(props){
 				</div>
 			</Modal.Body>
 			<Modal.Footer>
-			<Button variant="success" disabled={!columnLoad} onClick={handleUploadClose}>Upload</Button>
+			<Button variant="success"  onClick={handleUploadClose}>Upload</Button>
 			</Modal.Footer>
 		</Modal>
 		<Navbar sticky="top" bg="dark" variant="dark" className="bg-5">

--- a/src/ui_elements/Pages/main_upload.js
+++ b/src/ui_elements/Pages/main_upload.js
@@ -32,8 +32,12 @@ import {initFrameData, updateFrameData, getFrameData,
 		initCurrentFrame, getCurrentFrame, setCurrentFrame,
 		initMedia,
 		initMetadata, setRes, setFrameRate, setTotalFrames,
+        initColumnData,
 		initPlay} from '../../processing/actions'
 import { useSelector } from "react-redux";
+
+// Data imports
+import default_column from '../../static_data/basic_column_config.json'
 
 const fabric = require("fabric").fabric;
 
@@ -69,7 +73,10 @@ initFrameData(1)
 initCurrentFrame(0)
 initMetadata(scaling_factor_width, scaling_factor_height, 1, INPUT_VIDEO, 1)
 initPlay()
-
+console.log(default_column)
+initColumnData(
+    default_column
+)
 
 //Current frame counter
 export default function MainUpload() {


### PR DESCRIPTION
An earlier change forced the user to upload a column configuration. This however, causes user friction since it might slow down the rate at which people understand how the tool works. By allowing a default column configuration we are able to allow users to jump into the app right away, thus lowering confusion. 